### PR TITLE
fix: make the UX report describe what actually happened during a run

### DIFF
--- a/source/ci-runner.ts
+++ b/source/ci-runner.ts
@@ -104,6 +104,7 @@ export async function runCIAnalysis(config: UxLintConfig): Promise<void> {
 			totalDurationMs: totalDuration,
 			findingsCount: report.prioritizedFindings?.length ?? 0,
 			analyzedPages: report.metadata.analyzedPages.length,
+			partialPages: report.metadata.partialPages.length,
 			failedPages: report.metadata.failedPages.length,
 		});
 

--- a/source/ci-runner.ts
+++ b/source/ci-runner.ts
@@ -72,7 +72,11 @@ export async function runCIAnalysis(config: UxLintConfig): Promise<void> {
 
 			// Analyze page with minimal progress callback
 			// eslint-disable-next-line no-await-in-loop
-			await aiService.analyzePage(config, page, progressCallback);
+			const analysis = await aiService.analyzePage(
+				config,
+				page,
+				progressCallback,
+			);
 
 			const pageDuration = Date.now() - pageStartTime;
 			logger.info('Page analysis completed', {
@@ -80,6 +84,8 @@ export async function runCIAnalysis(config: UxLintConfig): Promise<void> {
 				totalPages,
 				url: page.url,
 				durationMs: pageDuration,
+				status: analysis.status,
+				error: analysis.error,
 			});
 		}
 
@@ -97,6 +103,8 @@ export async function runCIAnalysis(config: UxLintConfig): Promise<void> {
 			reportOutput: config.report.output,
 			totalDurationMs: totalDuration,
 			findingsCount: report.prioritizedFindings?.length ?? 0,
+			analyzedPages: report.metadata.analyzedPages.length,
+			failedPages: report.metadata.failedPages.length,
 		});
 
 		// Cleanup

--- a/source/infrastructure/reports/report-generator.ts
+++ b/source/infrastructure/reports/report-generator.ts
@@ -63,6 +63,10 @@ export function generateMarkdownReport(report: UxReport): string {
 		`**Generated**: ${formatTimestamp(metadata.timestamp)}`,
 		`**Pages Analyzed**: ${metadata.analyzedPages.length} successful`,
 	);
+	if (metadata.partialPages.length > 0) {
+		sections.push(`**Partial Pages**: ${metadata.partialPages.length}`);
+	}
+
 	if (metadata.failedPages.length > 0) {
 		sections.push(`**Failed Pages**: ${metadata.failedPages.length}`);
 	}
@@ -90,15 +94,24 @@ export function generateMarkdownReport(report: UxReport): string {
 
 	// Page Analyses Content
 	for (const page of pages) {
-		if (page.status !== 'complete') {
+		if (page.status !== 'complete' && page.status !== 'partial') {
 			continue;
 		}
 
+		const isPartial = page.status === 'partial';
+
 		sections.push(
-			`### ${page.pageUrl}\n`,
+			`### ${isPartial ? '⚠️ ' : ''}${page.pageUrl}\n`,
 			`**Features**: ${page.features}\n`,
-			`**Findings**: ${page.findings.length} issues identified\n`,
 		);
+
+		if (isPartial) {
+			sections.push(
+				'**Status**: Partial — the analysis was cut short, so this page is not fully covered.\n',
+			);
+		}
+
+		sections.push(`**Findings**: ${page.findings.length} issues identified\n`);
 
 		if (page.findings.length > 0) {
 			for (const finding of page.findings) {

--- a/source/infrastructure/reports/report-generator.ts
+++ b/source/infrastructure/reports/report-generator.ts
@@ -5,7 +5,11 @@
  * @packageDocumentation
  */
 
-import type {FindingSeverity, UxReport} from '../../models/analysis.js';
+import type {
+	FindingSeverity,
+	PageAnalysis,
+	UxReport,
+} from '../../models/analysis.js';
 
 /**
  * Severity emoji mapping
@@ -93,22 +97,30 @@ export function generateMarkdownReport(report: UxReport): string {
 	);
 
 	// Page Analyses Content
+	// Every page that produced findings is rendered, whatever ended it. The
+	// status note says how far the analysis got; omitting cut-short and failed
+	// pages hid findings that had already been paid for.
+	const statusNote: Partial<Record<PageAnalysis['status'], string>> = {
+		partial:
+			'**Status**: Partial — the analysis was cut short, so this page is not fully covered.\n',
+		failed:
+			'**Status**: Failed — findings below are only what was collected before the failure.\n',
+	};
+
 	for (const page of pages) {
-		if (page.status !== 'complete' && page.status !== 'partial') {
+		if (!['complete', 'partial', 'failed'].includes(page.status)) {
 			continue;
 		}
 
-		const isPartial = page.status === 'partial';
+		const note = statusNote[page.status];
 
 		sections.push(
-			`### ${isPartial ? '⚠️ ' : ''}${page.pageUrl}\n`,
+			`### ${note ? '⚠️ ' : ''}${page.pageUrl}\n`,
 			`**Features**: ${page.features}\n`,
 		);
 
-		if (isPartial) {
-			sections.push(
-				'**Status**: Partial — the analysis was cut short, so this page is not fully covered.\n',
-			);
+		if (note) {
+			sections.push(note);
 		}
 
 		sections.push(`**Findings**: ${page.findings.length} issues identified\n`);

--- a/source/infrastructure/reports/report-generator.ts
+++ b/source/infrastructure/reports/report-generator.ts
@@ -126,11 +126,18 @@ export function generateMarkdownReport(report: UxReport): string {
 		}
 	}
 
-	// Failed Pages
-	if (metadata.failedPages.length > 0) {
+	// Failed Pages. Read off `pages` rather than `metadata.failedPages` so the
+	// recorded reason is shown: a report that says a page failed without saying
+	// why sends the reader back to the log files.
+	const failedAnalyses = pages.filter(page => page.status === 'failed');
+	if (failedAnalyses.length > 0) {
 		sections.push('### Failed Pages\n');
-		for (const failedPage of metadata.failedPages) {
-			sections.push(`- ❌ ${failedPage}`);
+		for (const failedPage of failedAnalyses) {
+			sections.push(
+				`- ❌ ${failedPage.pageUrl}${
+					failedPage.error ? ` — ${failedPage.error}` : ''
+				}`,
+			);
 		}
 
 		sections.push('');

--- a/source/models/analysis.ts
+++ b/source/models/analysis.ts
@@ -12,7 +12,18 @@ import type {LLMResponseData} from './llm-response.js';
  * Represents the current state of page analysis
  */
 export type AnalysisStatus =
-	'pending' | 'navigating' | 'capturing' | 'analyzing' | 'complete' | 'failed';
+	| 'pending'
+	| 'navigating'
+	| 'capturing'
+	| 'analyzing'
+	| 'complete'
+	/**
+	 * The agent loop ended without the model signalling completion -- it ran
+	 * out of iterations. Findings collected so far are real, but the sweep is
+	 * unfinished, so this must never be reported as `complete`.
+	 */
+	| 'partial'
+	| 'failed';
 
 /**
  * Page analysis result
@@ -111,6 +122,11 @@ export type ReportMetadata = {
 	 * URLs successfully analyzed
 	 */
 	analyzedPages: string[];
+
+	/**
+	 * URLs whose analysis was cut short before the model signalled completion
+	 */
+	partialPages: string[];
 
 	/**
 	 * URLs that failed analysis (with reasons)

--- a/source/services/ai-service.ts
+++ b/source/services/ai-service.ts
@@ -103,19 +103,24 @@ export class AIService {
 	 * would not catch it either.
 	 */
 	async close(): Promise<void> {
-		if (this.mcpClient) {
-			await this.mcpClient.close();
-		}
+		try {
+			if (this.mcpClient) {
+				await this.mcpClient.close();
+			}
+		} finally {
+			// A transport that throws on the way down is still down. Leaving the
+			// caches populated because its close() failed reproduces the exact
+			// symptom this teardown exists to prevent.
+			this.reportBuilder.reset();
+			this.isClosed = true;
 
-		this.reportBuilder.reset();
-		this.isClosed = true;
-
-		// Only a cache-managed instance owns the module-level caches. A service
-		// constructed directly (tests) brings its own client and must not
-		// clobber them.
-		if (this.cacheKey) {
-			aiServiceInstances.delete(this.cacheKey);
-			resetMCPClient();
+			// Only a cache-managed instance owns the module-level caches. A
+			// service constructed directly (tests) brings its own client and
+			// must not clobber them.
+			if (this.cacheKey) {
+				aiServiceInstances.delete(this.cacheKey);
+				resetMCPClient();
+			}
 		}
 	}
 

--- a/source/services/ai-service.ts
+++ b/source/services/ai-service.ts
@@ -100,6 +100,12 @@ export class AIService {
 		}
 
 		try {
+			// The persona belongs to the run, not to a page, but nothing else
+			// records it: this used to live only in the error path, so a run
+			// where every page succeeded produced a report with a blank
+			// persona. Setting it here is idempotent.
+			this.reportBuilder.setPersona(config.persona);
+
 			// Initialize page analysis in report builder
 			this.reportBuilder.initializePageAnalysis(page.url, page.features);
 

--- a/source/services/ai-service.ts
+++ b/source/services/ai-service.ts
@@ -65,19 +65,40 @@ export class AIService {
 	private readonly model: LanguageModelV4;
 	private readonly mcpClient: MCPClient;
 	private readonly reportBuilder: ReportBuilder;
+	private readonly cacheKey: string | undefined;
+	private isClosed = false;
 
+	/**
+	 * Create an analysis service bound to one model and MCP connection.
+	 *
+	 * `cacheKey` is the key this instance is filed under in the module cache,
+	 * which lets `close()` evict itself. It is omitted when the service is
+	 * constructed directly, as tests do.
+	 *
+	 * @param model - Language model backing the analysis
+	 * @param mcpClient - Connected MCP client providing browser tools
+	 * @param builder - Report builder collecting findings
+	 * @param cacheKey - Module cache key for this instance
+	 */
 	constructor(
 		model: LanguageModelV4,
 		mcpClient: MCPClient,
 		builder: ReportBuilder,
+		cacheKey?: string,
 	) {
 		this.model = model;
 		this.mcpClient = mcpClient;
 		this.reportBuilder = builder;
+		this.cacheKey = cacheKey;
 	}
 
 	/**
 	 * Close the MCP client connection and reset state
+	 *
+	 * Also drops this instance from the module cache. Without that, a second
+	 * run in the same process got the same AIService back from `getAIService`
+	 * with its MCP client already closed, and failed on a dead transport
+	 * rather than starting a fresh one.
 	 */
 	async close(): Promise<void> {
 		if (this.mcpClient) {
@@ -85,6 +106,11 @@ export class AIService {
 		}
 
 		this.reportBuilder.reset();
+		this.isClosed = true;
+
+		if (this.cacheKey) {
+			aiServiceInstances.delete(this.cacheKey);
+		}
 	}
 
 	/**
@@ -97,6 +123,15 @@ export class AIService {
 	): Promise<PageAnalysis> {
 		if (!this.model || !this.mcpClient) {
 			throw new Error('AIService not initialized');
+		}
+
+		if (this.isClosed) {
+			// Name the real cause here. Letting this through surfaced whatever
+			// obscure error the closed MCP transport happened to raise.
+			return this.reportBuilder.failCurrentPage(
+				'AIService has been closed; create a new instance before analyzing again',
+				page,
+			);
 		}
 
 		try {
@@ -437,7 +472,7 @@ export async function getAIService(config: UxLintConfig): Promise<AIService> {
 	if (!aiServiceInstances.has(cacheKey)) {
 		const model = await getLanguageModel(config);
 		const client = await getMCPClient();
-		const service = new AIService(model, client, reportBuilder);
+		const service = new AIService(model, client, reportBuilder, cacheKey);
 		aiServiceInstances.set(cacheKey, service);
 	}
 

--- a/source/services/ai-service.ts
+++ b/source/services/ai-service.ts
@@ -99,8 +99,6 @@ export class AIService {
 			throw new Error('AIService not initialized');
 		}
 
-		const startTime = Date.now();
-
 		try {
 			// Initialize page analysis in report builder
 			this.reportBuilder.initializePageAnalysis(page.url, page.features);
@@ -233,19 +231,11 @@ export class AIService {
 				stack: error instanceof Error ? error.stack : undefined,
 			});
 
-			// Reset current page analysis on error
-			this.reportBuilder.reset();
-			this.reportBuilder.setPersona(config.persona);
-
-			return {
-				pageUrl: page.url,
-				features: page.features,
-				snapshot: '',
-				findings: [],
-				analysisTimestamp: startTime,
-				status: 'failed',
-				error: errorMessage,
-			};
+			// Record the failure and drop only this page. Calling reset() here
+			// emptied the whole run, so a single failing page erased every page
+			// already analysed -- and the hand-built result below was returned to
+			// a caller that discards it, leaving the failure out of the report.
+			return this.reportBuilder.failCurrentPage(errorMessage, page);
 		}
 	}
 

--- a/source/services/ai-service.ts
+++ b/source/services/ai-service.ts
@@ -198,11 +198,15 @@ export class AIService {
 				}
 			}
 
-			// If analysis was not completed properly, complete it now
+			// The loop ended without the model calling completePageAnalysis --
+			// it exhausted MAX_AGENT_ITERATIONS or stopped early. Close the page
+			// out as `partial`: recording it as `complete` made a truncated
+			// sweep indistinguishable from a finished one, which is exactly the
+			// distinction a CI gate has to be able to make.
 			if (!isAnalysisCompleted) {
 				const state = this.reportBuilder.getCurrentState();
 				if (state.currentPageAnalysis) {
-					this.reportBuilder.completePageAnalysis();
+					this.reportBuilder.completePageAnalysis('partial');
 				}
 			}
 

--- a/source/services/ai-service.ts
+++ b/source/services/ai-service.ts
@@ -16,7 +16,7 @@ import type {AnalysisStage, PageAnalysis} from '../models/analysis.js';
 import type {Page, UxLintConfig} from '../models/config.js';
 import type {LLMResponseData} from '../models/llm-response.js';
 import {getLanguageModel} from './llm-provider.js';
-import {getMCPClient} from './mcp-client.js';
+import {getMCPClient, resetMCPClient} from './mcp-client.js';
 import {reportBuilder, type ReportBuilder} from './report-builder.js';
 
 /**
@@ -95,10 +95,12 @@ export class AIService {
 	/**
 	 * Close the MCP client connection and reset state
 	 *
-	 * Also drops this instance from the module cache. Without that, a second
-	 * run in the same process got the same AIService back from `getAIService`
-	 * with its MCP client already closed, and failed on a dead transport
-	 * rather than starting a fresh one.
+	 * Both caches in front of this object have to be cleared, not just one.
+	 * `getAIService` memoises the service and `getMCPClient` memoises the
+	 * transport at module scope, so dropping only the service handed the next
+	 * run a brand new AIService wrapped around the same closed client -- and
+	 * because that instance is not itself closed, the guard in `analyzePage`
+	 * would not catch it either.
 	 */
 	async close(): Promise<void> {
 		if (this.mcpClient) {
@@ -108,8 +110,12 @@ export class AIService {
 		this.reportBuilder.reset();
 		this.isClosed = true;
 
+		// Only a cache-managed instance owns the module-level caches. A service
+		// constructed directly (tests) brings its own client and must not
+		// clobber them.
 		if (this.cacheKey) {
 			aiServiceInstances.delete(this.cacheKey);
+			resetMCPClient();
 		}
 	}
 
@@ -126,12 +132,21 @@ export class AIService {
 		}
 
 		if (this.isClosed) {
-			// Name the real cause here. Letting this through surfaced whatever
-			// obscure error the closed MCP transport happened to raise.
-			return this.reportBuilder.failCurrentPage(
-				'AIService has been closed; create a new instance before analyzing again',
-				page,
-			);
+			// Name the real cause instead of letting the closed transport raise
+			// whatever it raises. Reported straight to the caller and not through
+			// the builder: close() reset that builder, and it is the process-wide
+			// singleton the *next* run will use, so writing here would plant a
+			// phantom failed page in a report for a run that never saw this page.
+			return {
+				pageUrl: page.url,
+				features: page.features,
+				snapshot: '',
+				findings: [],
+				analysisTimestamp: Date.now(),
+				status: 'failed',
+				error:
+					'AIService has been closed; create a new instance before analyzing again',
+			};
 		}
 
 		try {

--- a/source/services/report-builder.ts
+++ b/source/services/report-builder.ts
@@ -117,6 +117,53 @@ export class ReportBuilder {
 	}
 
 	/**
+	 * Drop the in-flight page analysis without touching the rest of the run.
+	 *
+	 * `reset()` is for run boundaries: it also empties `allAnalyses`. Using it
+	 * to abandon a single page threw away every page already completed, so one
+	 * flaky page cost the whole report.
+	 */
+	discardCurrentPage(): void {
+		this.currentPageAnalysis = undefined;
+	}
+
+	/**
+	 * Record the in-flight page as failed and move it into the collection.
+	 *
+	 * A failure that leaves no trace is indistinguishable from a page that was
+	 * never requested, which is why `metadata.failedPages` was always empty.
+	 *
+	 * `page` is the fallback identity for a failure that happened before
+	 * `initializePageAnalysis` ran, when there is no in-flight analysis to convert.
+	 *
+	 * @param error - Why the page failed
+	 * @param page - Page identity to fall back on
+	 * @param page.url - Page URL
+	 * @param page.features - Feature descriptions from config
+	 * @returns The recorded failed analysis
+	 */
+	failCurrentPage(
+		error: string,
+		page: {url: string; features: string},
+	): PageAnalysis {
+		const failedAnalysis: PageAnalysis = {
+			pageUrl: this.currentPageAnalysis?.pageUrl ?? page.url,
+			features: this.currentPageAnalysis?.features ?? page.features,
+			snapshot: this.currentPageAnalysis?.snapshot ?? '',
+			findings: this.currentPageAnalysis?.findings ?? [],
+			analysisTimestamp:
+				this.currentPageAnalysis?.analysisTimestamp ?? Date.now(),
+			status: 'failed',
+			error,
+		};
+
+		this.allAnalyses.push(failedAnalysis);
+		this.currentPageAnalysis = undefined;
+
+		return failedAnalysis;
+	}
+
+	/**
 	 * Set persona for the report
 	 *
 	 * @param persona - Target persona

--- a/source/services/report-builder.ts
+++ b/source/services/report-builder.ts
@@ -225,13 +225,12 @@ export class ReportBuilder {
 		const partialAnalyses = analyses.filter(a => a.status === 'partial');
 		const failedAnalyses = analyses.filter(a => a.status === 'failed');
 
-		// Collect all findings. A partial analysis stopped early, but what it
-		// did observe is as real as anything from a finished page -- dropping
-		// those findings would make marking pages partial worse than not
-		// distinguishing them at all.
-		const allFindings = [...successfulAnalyses, ...partialAnalyses].flatMap(
-			a => a.findings,
-		);
+		// Every observation counts, whatever ended the page. A page cut short at
+		// iteration 20, or one that threw on iteration 15, still found what it
+		// found beforehand; discarding that is the same mistake as wiping
+		// completed pages on failure. How much of the page was covered is
+		// carried by the status split above, not by hiding findings.
+		const allFindings = analyses.flatMap(a => a.findings);
 
 		// Sort findings by severity
 		const prioritizedFindings = this.prioritizeFindings(allFindings);

--- a/source/services/report-builder.ts
+++ b/source/services/report-builder.ts
@@ -80,10 +80,16 @@ export class ReportBuilder {
 	/**
 	 * Complete the current page analysis and add it to collection
 	 *
+	 * `'partial'` is for a run that ended without the model signalling
+	 * completion -- it exhausted its iterations rather than finishing.
+	 *
+	 * @param status - Terminal status for the page; defaults to `'complete'`
 	 * @returns The completed page analysis
 	 * @throws Error if no page analysis is initialized or required fields are missing
 	 */
-	completePageAnalysis(): PageAnalysis {
+	completePageAnalysis(
+		status: 'complete' | 'partial' = 'complete',
+	): PageAnalysis {
 		if (!this.currentPageAnalysis) {
 			throw new Error(
 				'No page analysis initialized. Call initializePageAnalysis first.',
@@ -107,7 +113,7 @@ export class ReportBuilder {
 			findings: this.currentPageAnalysis.findings ?? [],
 			analysisTimestamp:
 				this.currentPageAnalysis.analysisTimestamp ?? Date.now(),
-			status: 'complete',
+			status,
 		};
 
 		this.allAnalyses.push(completedAnalysis);
@@ -205,10 +211,16 @@ export class ReportBuilder {
 	 */
 	generateReport(analyses: PageAnalysis[], persona: string): UxReport {
 		const successfulAnalyses = analyses.filter(a => a.status === 'complete');
+		const partialAnalyses = analyses.filter(a => a.status === 'partial');
 		const failedAnalyses = analyses.filter(a => a.status === 'failed');
 
-		// Collect all findings
-		const allFindings = successfulAnalyses.flatMap(a => a.findings);
+		// Collect all findings. A partial analysis stopped early, but what it
+		// did observe is as real as anything from a finished page -- dropping
+		// those findings would make marking pages partial worse than not
+		// distinguishing them at all.
+		const allFindings = [...successfulAnalyses, ...partialAnalyses].flatMap(
+			a => a.findings,
+		);
 
 		// Sort findings by severity
 		const prioritizedFindings = this.prioritizeFindings(allFindings);
@@ -217,12 +229,14 @@ export class ReportBuilder {
 		const summary = this.generateSummary(
 			successfulAnalyses.length,
 			allFindings.length,
+			partialAnalyses.length,
 		);
 
 		return {
 			metadata: {
 				timestamp: Date.now(),
 				analyzedPages: successfulAnalyses.map(a => a.pageUrl),
+				partialPages: partialAnalyses.map(a => a.pageUrl),
 				failedPages: failedAnalyses.map(a => a.pageUrl),
 				totalFindings: allFindings.length,
 				persona,
@@ -284,12 +298,21 @@ export class ReportBuilder {
 	/**
 	 * Generate executive summary
 	 */
-	private generateSummary(successCount: number, findingsCount: number): string {
-		if (successCount === 0) {
+	private generateSummary(
+		successCount: number,
+		findingsCount: number,
+		partialCount: number,
+	): string {
+		if (successCount === 0 && partialCount === 0) {
 			return 'All pages failed analysis. Please check error messages and try again.';
 		}
 
-		return `Analyzed ${successCount} page(s) successfully. Found ${findingsCount} UX issue(s) requiring attention.`;
+		const partialNote =
+			partialCount > 0
+				? ` ${partialCount} page(s) were cut short before the analysis finished, so their coverage is incomplete.`
+				: '';
+
+		return `Analyzed ${successCount} page(s) successfully. Found ${findingsCount} UX issue(s) requiring attention.${partialNote}`;
 	}
 }
 

--- a/source/services/report-builder.ts
+++ b/source/services/report-builder.ts
@@ -123,21 +123,13 @@ export class ReportBuilder {
 	}
 
 	/**
-	 * Drop the in-flight page analysis without touching the rest of the run.
-	 *
-	 * `reset()` is for run boundaries: it also empties `allAnalyses`. Using it
-	 * to abandon a single page threw away every page already completed, so one
-	 * flaky page cost the whole report.
-	 */
-	discardCurrentPage(): void {
-		this.currentPageAnalysis = undefined;
-	}
-
-	/**
 	 * Record the in-flight page as failed and move it into the collection.
 	 *
 	 * A failure that leaves no trace is indistinguishable from a page that was
 	 * never requested, which is why `metadata.failedPages` was always empty.
+	 * Note that `reset()` is for run boundaries -- it also empties
+	 * `allAnalyses`, so using it to abandon one page threw away every page
+	 * already completed.
 	 *
 	 * `page` is the fallback identity for a failure that happened before
 	 * `initializePageAnalysis` ran, when there is no in-flight analysis to convert.
@@ -146,12 +138,31 @@ export class ReportBuilder {
 	 * @param page - Page identity to fall back on
 	 * @param page.url - Page URL
 	 * @param page.features - Feature descriptions from config
-	 * @returns The recorded failed analysis
+	 * @returns The recorded failed analysis, or the existing terminal record
 	 */
 	failCurrentPage(
 		error: string,
 		page: {url: string; features: string},
 	): PageAnalysis {
+		if (!this.currentPageAnalysis) {
+			// No in-flight page means one of two things, and they need opposite
+			// handling: the page was never initialised (record the failure), or
+			// it already reached a terminal state and something after that threw
+			// (do not record it again). Pushing a second record would list the
+			// same URL under both analyzedPages and failedPages and report a
+			// finished page as failed.
+			// Scanning backwards so a URL that legitimately appears twice in the
+			// config resolves to its most recent record. `findLast` would say
+			// this in one line but is ES2023, and tsconfig targets ES2022 libs.
+			for (let index = this.allAnalyses.length - 1; index >= 0; index--) {
+				const settled = this.allAnalyses[index];
+
+				if (settled?.pageUrl === page.url) {
+					return settled;
+				}
+			}
+		}
+
 		const failedAnalysis: PageAnalysis = {
 			pageUrl: this.currentPageAnalysis?.pageUrl ?? page.url,
 			features: this.currentPageAnalysis?.features ?? page.features,
@@ -307,12 +318,16 @@ export class ReportBuilder {
 			return 'All pages failed analysis. Please check error messages and try again.';
 		}
 
-		const partialNote =
+		// The finding count spans complete and partial pages, so the sentence
+		// has to account for both. Crediting them all to successCount read as a
+		// contradiction whenever a run was mostly partial ("Analyzed 0 page(s)
+		// successfully. Found 12 UX issue(s)").
+		const coverage =
 			partialCount > 0
-				? ` ${partialCount} page(s) were cut short before the analysis finished, so their coverage is incomplete.`
-				: '';
+				? `Analyzed ${successCount} page(s) fully and ${partialCount} page(s) partially -- the partial ones were cut short, so their coverage is incomplete.`
+				: `Analyzed ${successCount} page(s) successfully.`;
 
-		return `Analyzed ${successCount} page(s) successfully. Found ${findingsCount} UX issue(s) requiring attention.${partialNote}`;
+		return `${coverage} Found ${findingsCount} UX issue(s) requiring attention.`;
 	}
 }
 

--- a/tests/infrastructure/reports/report-generator.spec.ts
+++ b/tests/infrastructure/reports/report-generator.spec.ts
@@ -71,6 +71,31 @@ test('a partial page is flagged instead of passing as analysed', t => {
 	t.regex(markdown, /Pages Analyzed\*\*: 0 successful/);
 });
 
+test('a failed page still shows what it managed to find', t => {
+	const markdown = generateMarkdownReport(
+		buildReport([
+			buildPage({
+				pageUrl: 'https://example.com/died',
+				status: 'failed',
+				error: 'threw on iteration 15',
+				findings: [
+					{
+						severity: 'high',
+						category: 'Accessibility',
+						description: 'Missing alt text',
+						personaRelevance: ['Test persona'],
+						recommendation: 'Add alt text',
+						pageUrl: 'https://example.com/died',
+					},
+				],
+			}),
+		]),
+	);
+
+	t.regex(markdown, /Missing alt text/, 'pre-failure findings are rendered');
+	t.regex(markdown, /Status\*\*: Failed/);
+});
+
 test('a fully analysed page renders no partial or failure noise', t => {
 	const markdown = generateMarkdownReport(
 		buildReport([buildPage({pageUrl: 'https://example.com/ok'})]),

--- a/tests/infrastructure/reports/report-generator.spec.ts
+++ b/tests/infrastructure/reports/report-generator.spec.ts
@@ -1,0 +1,82 @@
+/**
+ * Unit tests for markdown report rendering
+ *
+ * The generator is a pure function over UxReport, so Constitution II puts it
+ * under unit tests. It had none, which is why a page could be recorded as
+ * failed and still render without saying why.
+ */
+
+import test from 'ava';
+import type {PageAnalysis, UxReport} from '../../../source/models/analysis.js';
+import {generateMarkdownReport} from '../../../source/infrastructure/reports/report-generator.js';
+
+const buildPage = (overrides: Partial<PageAnalysis>): PageAnalysis => ({
+	pageUrl: 'https://example.com',
+	features: 'features',
+	snapshot: '',
+	findings: [],
+	analysisTimestamp: 0,
+	status: 'complete',
+	...overrides,
+});
+
+const buildReport = (pages: PageAnalysis[]): UxReport => ({
+	metadata: {
+		timestamp: 0,
+		analyzedPages: pages
+			.filter(page => page.status === 'complete')
+			.map(page => page.pageUrl),
+		partialPages: pages
+			.filter(page => page.status === 'partial')
+			.map(page => page.pageUrl),
+		failedPages: pages
+			.filter(page => page.status === 'failed')
+			.map(page => page.pageUrl),
+		totalFindings: 0,
+		persona: 'Test persona',
+	},
+	pages,
+	summary: 'Test summary',
+	prioritizedFindings: [],
+});
+
+test('a failed page renders with the reason it failed', t => {
+	const markdown = generateMarkdownReport(
+		buildReport([
+			buildPage({
+				pageUrl: 'https://example.com/broken',
+				status: 'failed',
+				error: 'navigation timed out',
+			}),
+		]),
+	);
+
+	t.regex(markdown, /https:\/\/example\.com\/broken/);
+	t.regex(
+		markdown,
+		/navigation timed out/,
+		'a report that says a page failed without saying why sends the reader to the log files',
+	);
+});
+
+test('a partial page is flagged instead of passing as analysed', t => {
+	const markdown = generateMarkdownReport(
+		buildReport([
+			buildPage({pageUrl: 'https://example.com/cut', status: 'partial'}),
+		]),
+	);
+
+	t.regex(markdown, /\*\*Partial Pages\*\*: 1/);
+	t.regex(markdown, /Partial — the analysis was cut short/);
+	t.regex(markdown, /Pages Analyzed\*\*: 0 successful/);
+});
+
+test('a fully analysed page renders no partial or failure noise', t => {
+	const markdown = generateMarkdownReport(
+		buildReport([buildPage({pageUrl: 'https://example.com/ok'})]),
+	);
+
+	t.notRegex(markdown, /Partial Pages/);
+	t.notRegex(markdown, /Failed Pages/);
+	t.regex(markdown, /### https:\/\/example\.com\/ok/);
+});

--- a/tests/models/ci-mode.spec.ts
+++ b/tests/models/ci-mode.spec.ts
@@ -20,6 +20,7 @@ const createMockReport = (): UxReport => ({
 	metadata: {
 		timestamp: 0,
 		analyzedPages: [],
+		partialPages: [],
 		failedPages: [],
 		totalFindings: 0,
 		persona: 'test persona',

--- a/tests/models/uxlint-machine.spec.ts
+++ b/tests/models/uxlint-machine.spec.ts
@@ -19,6 +19,7 @@ const createMockReport = (summary = 'test summary'): UxReport => ({
 	metadata: {
 		timestamp: 0,
 		analyzedPages: [],
+		partialPages: [],
 		failedPages: [],
 		totalFindings: 0,
 		persona: 'test persona',

--- a/tests/services/ai-service.spec.ts
+++ b/tests/services/ai-service.spec.ts
@@ -207,10 +207,9 @@ test('AIService generates valid report when LLM completes page analysis using Mo
 	t.is(pageAnalysis.pageUrl, 'https://example.com');
 	t.is(pageAnalysis.status, 'complete');
 
-	// Set persona for report generation
-	reportBuilder.setPersona(config.persona);
-
-	// Generate final report
+	// Deliberately no setPersona call: analyzePage owns that now. Calling it
+	// from the test is what hid the fact that the production success path
+	// never set it at all.
 	const report = reportBuilder.generateFinalReport();
 
 	// Verify report is not empty and contains expected data
@@ -650,6 +649,41 @@ test('AIService marks an iteration-exhausted analysis as partial', async t => {
 	const report = reportBuilder.generateFinalReport();
 	t.deepEqual(report.metadata.partialPages, ['https://example.com/loops']);
 	t.deepEqual(report.metadata.analyzedPages, []);
+
+	sandbox.restore();
+});
+
+test('AIService sets the report persona without the caller doing it', async t => {
+	const sandbox = sinon.createSandbox();
+	const config = multiPageConfig(['https://example.com/one']);
+	const mockModel = new MockLanguageModelV4({
+		async doGenerate() {
+			return toolCallStep('completePageAnalysis');
+		},
+	});
+
+	const reportBuilder = createBuilder(sandbox);
+	const aiService = new AIService(
+		mockModel,
+		createMockMCPClient(),
+		reportBuilder,
+	);
+
+	const page = config.pages[0];
+
+	if (!page) {
+		t.fail('Page is undefined');
+		return;
+	}
+
+	await aiService.analyzePage(config, page);
+
+	const report = reportBuilder.generateFinalReport();
+	t.is(
+		report.metadata.persona,
+		'Test persona',
+		'persona must be recorded on the success path, not only when a page fails',
+	);
 
 	sandbox.restore();
 });

--- a/tests/services/ai-service.spec.ts
+++ b/tests/services/ai-service.spec.ts
@@ -687,3 +687,39 @@ test('AIService sets the report persona without the caller doing it', async t =>
 
 	sandbox.restore();
 });
+
+test('AIService refuses to analyse after close instead of using a dead client', async t => {
+	const sandbox = sinon.createSandbox();
+	const config = multiPageConfig(['https://example.com/one']);
+	const mockModel = new MockLanguageModelV4({
+		async doGenerate() {
+			return toolCallStep('completePageAnalysis');
+		},
+	});
+
+	const reportBuilder = createBuilder(sandbox);
+	const aiService = new AIService(
+		mockModel,
+		createMockMCPClient(),
+		reportBuilder,
+	);
+
+	const page = config.pages[0];
+
+	if (!page) {
+		t.fail('Page is undefined');
+		return;
+	}
+
+	await aiService.close();
+	const analysis = await aiService.analyzePage(config, page);
+
+	t.is(analysis.status, 'failed');
+	t.regex(
+		analysis.error ?? '',
+		/closed/i,
+		'the error should name the real cause instead of surfacing an MCP failure',
+	);
+
+	sandbox.restore();
+});

--- a/tests/services/ai-service.spec.ts
+++ b/tests/services/ai-service.spec.ts
@@ -470,3 +470,136 @@ test('AIService surfaces tool call arguments in the LLM response sent to the UI'
 	await aiService.close();
 	sandbox.restore();
 });
+
+const mockUsage = {
+	inputTokens: {
+		total: 10,
+		noCache: 10,
+		cacheRead: undefined,
+		cacheWrite: undefined,
+	},
+	outputTokens: {total: 20, text: 20, reasoning: undefined},
+} as const;
+
+/** A step that calls one report tool with the given JSON input. */
+const toolCallStep = (toolName: string, input = '{}') => ({
+	finishReason: {unified: 'tool-calls' as const, raw: undefined},
+	usage: mockUsage,
+	content: [
+		{
+			type: 'tool-call' as const,
+			toolCallId: `call-${toolName}`,
+			toolName,
+			input,
+		},
+	],
+	warnings: [],
+});
+
+const multiPageConfig = (urls: string[]): UxLintConfig => ({
+	mainPageUrl: urls[0] ?? 'https://example.com',
+	subPageUrls: urls.slice(1),
+	pages: urls.map(url => ({url, features: `Features for ${url}`})),
+	persona: 'Test persona',
+	report: {output: './test-report.md'},
+});
+
+const createBuilder = (sandbox: sinon.SinonSandbox) =>
+	new ReportBuilder({
+		...fsPromises,
+		writeFile: sandbox.stub().resolves(),
+	});
+
+test('AIService keeps earlier page findings when a later page throws', async t => {
+	const sandbox = sinon.createSandbox();
+	const config = multiPageConfig([
+		'https://example.com/one',
+		'https://example.com/two',
+		'https://example.com/three',
+	]);
+
+	// The failing page is the second of three, so the assertion can tell
+	// "prior work survived" apart from "nothing ran".
+	let pageIndex = 0;
+	const mockModel = new MockLanguageModelV4({
+		async doGenerate() {
+			if (pageIndex === 1) {
+				throw new Error('navigation timed out');
+			}
+
+			return toolCallStep(
+				'addFinding',
+				JSON.stringify({
+					severity: 'high',
+					category: 'Accessibility',
+					description: `Issue on page ${pageIndex}`,
+					personaRelevance: ['Test persona'],
+					recommendation: 'Fix it',
+					pageUrl: config.pages[pageIndex]?.url ?? '',
+				}),
+			);
+		},
+	});
+
+	const reportBuilder = createBuilder(sandbox);
+	const aiService = new AIService(
+		mockModel,
+		createMockMCPClient(),
+		reportBuilder,
+	);
+
+	const results = [];
+	for (const [index, page] of config.pages.entries()) {
+		pageIndex = index;
+		// eslint-disable-next-line no-await-in-loop -- pages are analysed in order
+		results.push(await aiService.analyzePage(config, page));
+	}
+
+	t.is(results[1]?.status, 'failed');
+
+	const report = reportBuilder.generateFinalReport();
+
+	t.true(
+		report.metadata.analyzedPages.includes('https://example.com/one'),
+		'a mid-run failure must not erase the pages already analysed',
+	);
+	t.true(report.metadata.analyzedPages.includes('https://example.com/three'));
+	t.true(
+		report.metadata.totalFindings > 0,
+		'findings collected before the failure must survive',
+	);
+
+	sandbox.restore();
+});
+
+test('AIService records a failed page in the report metadata', async t => {
+	const sandbox = sinon.createSandbox();
+	const config = multiPageConfig(['https://example.com/broken']);
+	const mockModel = new MockLanguageModelV4({
+		async doGenerate() {
+			throw new Error('navigation timed out');
+		},
+	});
+
+	const reportBuilder = createBuilder(sandbox);
+	const aiService = new AIService(
+		mockModel,
+		createMockMCPClient(),
+		reportBuilder,
+	);
+
+	const page = config.pages[0]!;
+	const analysis = await aiService.analyzePage(config, page);
+
+	t.is(analysis.status, 'failed');
+	t.is(analysis.error, 'navigation timed out');
+
+	const report = reportBuilder.generateFinalReport();
+	t.deepEqual(
+		report.metadata.failedPages,
+		['https://example.com/broken'],
+		'a failed page has to leave a trace in the report',
+	);
+
+	sandbox.restore();
+});

--- a/tests/services/ai-service.spec.ts
+++ b/tests/services/ai-service.spec.ts
@@ -496,6 +496,14 @@ const toolCallStep = (toolName: string, input = '{}') => ({
 	warnings: [],
 });
 
+/** A step that stops with plain text and no tool calls. */
+const stopStep = () => ({
+	finishReason: {unified: 'stop' as const, raw: undefined},
+	usage: mockUsage,
+	content: [],
+	warnings: [],
+});
+
 const multiPageConfig = (urls: string[]): UxLintConfig => ({
 	mainPageUrl: urls[0] ?? 'https://example.com',
 	subPageUrls: urls.slice(1),
@@ -558,12 +566,13 @@ test('AIService keeps earlier page findings when a later page throws', async t =
 	t.is(results[1]?.status, 'failed');
 
 	const report = reportBuilder.generateFinalReport();
+	const recordedUrls = new Set(report.pages.map(page => page.pageUrl));
 
 	t.true(
-		report.metadata.analyzedPages.includes('https://example.com/one'),
+		recordedUrls.has('https://example.com/one'),
 		'a mid-run failure must not erase the pages already analysed',
 	);
-	t.true(report.metadata.analyzedPages.includes('https://example.com/three'));
+	t.true(recordedUrls.has('https://example.com/three'));
 	t.true(
 		report.metadata.totalFindings > 0,
 		'findings collected before the failure must survive',
@@ -600,6 +609,47 @@ test('AIService records a failed page in the report metadata', async t => {
 		['https://example.com/broken'],
 		'a failed page has to leave a trace in the report',
 	);
+
+	sandbox.restore();
+});
+
+test('AIService marks an iteration-exhausted analysis as partial', async t => {
+	const sandbox = sinon.createSandbox();
+	const config = multiPageConfig(['https://example.com/loops']);
+
+	// Never calls completePageAnalysis, so the loop runs to
+	// MAX_AGENT_ITERATIONS and falls through to the terminal path.
+	const mockModel = new MockLanguageModelV4({
+		async doGenerate() {
+			return stopStep();
+		},
+	});
+
+	const reportBuilder = createBuilder(sandbox);
+	const aiService = new AIService(
+		mockModel,
+		createMockMCPClient(),
+		reportBuilder,
+	);
+
+	const page = config.pages[0];
+
+	if (!page) {
+		t.fail('Page is undefined');
+		return;
+	}
+
+	const analysis = await aiService.analyzePage(config, page);
+
+	t.is(
+		analysis.status,
+		'partial',
+		'a truncated analysis must not be indistinguishable from a finished one',
+	);
+
+	const report = reportBuilder.generateFinalReport();
+	t.deepEqual(report.metadata.partialPages, ['https://example.com/loops']);
+	t.deepEqual(report.metadata.analyzedPages, []);
 
 	sandbox.restore();
 });

--- a/tests/services/report-builder.spec.ts
+++ b/tests/services/report-builder.spec.ts
@@ -170,6 +170,33 @@ test('generateReport separates complete, partial and failed pages', t => {
 	sandbox.restore();
 });
 
+test('findings collected before a failure still reach the report', t => {
+	const {builder, sandbox} = createBuilder();
+
+	// The page called addFinding a few times and then threw. Those findings
+	// were already paid for; dropping them is the same mistake as wiping
+	// completed pages on failure.
+	builder.initializePageAnalysis('https://example.com/died', 'features');
+	builder.addFinding(buildFinding('https://example.com/died'));
+	builder.failCurrentPage('threw on iteration 15', {
+		url: 'https://example.com/died',
+		features: 'features',
+	});
+
+	const report = builder.generateFinalReport();
+
+	t.is(report.metadata.totalFindings, 1);
+	t.is(report.prioritizedFindings.length, 1);
+	t.deepEqual(report.metadata.failedPages, ['https://example.com/died']);
+	t.deepEqual(
+		report.metadata.analyzedPages,
+		[],
+		'the page still does not count as analysed',
+	);
+
+	sandbox.restore();
+});
+
 test('reset still clears the whole run', t => {
 	const {builder, sandbox} = createBuilder();
 

--- a/tests/services/report-builder.spec.ts
+++ b/tests/services/report-builder.spec.ts
@@ -1,0 +1,160 @@
+/**
+ * Unit tests for ReportBuilder state transitions
+ *
+ * ReportBuilder is a pure TypeScript class, so Constitution II puts it under
+ * unit tests. It had none, which is how the page-termination bugs guarded
+ * below survived: every one of them lives in the gap between "the current page
+ * ended" and "the run ended", and nothing exercised that boundary.
+ */
+
+import {promises as fsPromises} from 'node:fs';
+import test from 'ava';
+import sinon from 'sinon';
+import type {UxFinding} from '../../source/models/analysis.js';
+import {ReportBuilder} from '../../source/services/report-builder.js';
+
+const buildFinding = (
+	pageUrl: string,
+	category = 'Accessibility',
+): UxFinding => ({
+	severity: 'high',
+	category,
+	description: `Issue on ${pageUrl}`,
+	personaRelevance: ['Test persona'],
+	recommendation: 'Fix it',
+	pageUrl,
+});
+
+const createBuilder = () => {
+	const sandbox = sinon.createSandbox();
+	const builder = new ReportBuilder({
+		...fsPromises,
+		writeFile: sandbox.stub().resolves(),
+	});
+
+	return {builder, sandbox};
+};
+
+/**
+ * Complete one page with a single finding, so tests have prior work that a
+ * later failure must not destroy.
+ */
+const completeOnePage = (builder: ReportBuilder, pageUrl: string) => {
+	builder.initializePageAnalysis(pageUrl, 'features');
+	builder.addFinding(buildFinding(pageUrl));
+	builder.completePageAnalysis();
+};
+
+test('discardCurrentPage drops only the in-flight page', t => {
+	const {builder, sandbox} = createBuilder();
+
+	builder.setPersona('Test persona');
+	completeOnePage(builder, 'https://example.com/one');
+
+	builder.initializePageAnalysis('https://example.com/two', 'features');
+	builder.addFinding(buildFinding('https://example.com/two'));
+	builder.discardCurrentPage();
+
+	const state = builder.getCurrentState();
+	t.is(state.currentPageAnalysis, undefined);
+	t.is(state.completedAnalyses.length, 1);
+	t.is(state.completedAnalyses[0]?.pageUrl, 'https://example.com/one');
+	t.is(state.persona, 'Test persona', 'persona must survive a page discard');
+
+	sandbox.restore();
+});
+
+test('failCurrentPage records the failure without destroying earlier pages', t => {
+	const {builder, sandbox} = createBuilder();
+
+	builder.setPersona('Test persona');
+	completeOnePage(builder, 'https://example.com/one');
+
+	builder.initializePageAnalysis('https://example.com/two', 'features');
+	const failed = builder.failCurrentPage('navigation timed out', {
+		url: 'https://example.com/two',
+		features: 'features',
+	});
+
+	t.is(failed.status, 'failed');
+	t.is(failed.error, 'navigation timed out');
+
+	const state = builder.getCurrentState();
+	t.is(state.currentPageAnalysis, undefined);
+	t.is(state.completedAnalyses.length, 2);
+	t.is(
+		state.completedAnalyses[0]?.pageUrl,
+		'https://example.com/one',
+		'the page completed before the failure must still be there',
+	);
+	t.is(state.completedAnalyses[0]?.findings.length, 1);
+	t.is(state.persona, 'Test persona');
+
+	sandbox.restore();
+});
+
+test('failCurrentPage synthesises a record when the page never initialised', t => {
+	const {builder, sandbox} = createBuilder();
+
+	// Reproduces a throw before initializePageAnalysis runs -- there is no
+	// current page to convert, but the run still needs the failure recorded.
+	const failed = builder.failCurrentPage('MCP client unavailable', {
+		url: 'https://example.com/never-started',
+		features: 'features',
+	});
+
+	t.is(failed.pageUrl, 'https://example.com/never-started');
+	t.is(failed.features, 'features');
+	t.is(failed.status, 'failed');
+	t.is(failed.error, 'MCP client unavailable');
+	t.is(builder.getCurrentState().completedAnalyses.length, 1);
+
+	sandbox.restore();
+});
+
+test('completePageAnalysis still defaults to complete', t => {
+	const {builder, sandbox} = createBuilder();
+
+	builder.initializePageAnalysis('https://example.com/one', 'features');
+	t.is(builder.completePageAnalysis().status, 'complete');
+
+	sandbox.restore();
+});
+
+test('generateReport separates completed pages from failed ones', t => {
+	const {builder, sandbox} = createBuilder();
+
+	builder.setPersona('Test persona');
+	completeOnePage(builder, 'https://example.com/complete');
+
+	builder.initializePageAnalysis('https://example.com/failed', 'features');
+	builder.failCurrentPage('boom', {
+		url: 'https://example.com/failed',
+		features: 'features',
+	});
+
+	const report = builder.generateFinalReport();
+
+	t.deepEqual(report.metadata.analyzedPages, ['https://example.com/complete']);
+	t.deepEqual(report.metadata.failedPages, ['https://example.com/failed']);
+	t.is(report.metadata.totalFindings, 1);
+	t.is(report.pages.length, 2, 'every page appears in the report body');
+	t.is(report.metadata.persona, 'Test persona');
+
+	sandbox.restore();
+});
+
+test('reset still clears the whole run', t => {
+	const {builder, sandbox} = createBuilder();
+
+	builder.setPersona('Test persona');
+	completeOnePage(builder, 'https://example.com/one');
+	builder.reset();
+
+	const state = builder.getCurrentState();
+	t.is(state.completedAnalyses.length, 0);
+	t.is(state.currentPageAnalysis, undefined);
+	t.is(state.persona, '');
+
+	sandbox.restore();
+});

--- a/tests/services/report-builder.spec.ts
+++ b/tests/services/report-builder.spec.ts
@@ -112,6 +112,19 @@ test('failCurrentPage synthesises a record when the page never initialised', t =
 	sandbox.restore();
 });
 
+test('completePageAnalysis marks the page partial when asked', t => {
+	const {builder, sandbox} = createBuilder();
+
+	builder.initializePageAnalysis('https://example.com/one', 'features');
+	builder.addFinding(buildFinding('https://example.com/one'));
+	const analysis = builder.completePageAnalysis('partial');
+
+	t.is(analysis.status, 'partial');
+	t.is(builder.getCurrentState().completedAnalyses[0]?.status, 'partial');
+
+	sandbox.restore();
+});
+
 test('completePageAnalysis still defaults to complete', t => {
 	const {builder, sandbox} = createBuilder();
 
@@ -121,11 +134,15 @@ test('completePageAnalysis still defaults to complete', t => {
 	sandbox.restore();
 });
 
-test('generateReport separates completed pages from failed ones', t => {
+test('generateReport separates complete, partial and failed pages', t => {
 	const {builder, sandbox} = createBuilder();
 
 	builder.setPersona('Test persona');
 	completeOnePage(builder, 'https://example.com/complete');
+
+	builder.initializePageAnalysis('https://example.com/partial', 'features');
+	builder.addFinding(buildFinding('https://example.com/partial', 'Navigation'));
+	builder.completePageAnalysis('partial');
 
 	builder.initializePageAnalysis('https://example.com/failed', 'features');
 	builder.failCurrentPage('boom', {
@@ -136,9 +153,14 @@ test('generateReport separates completed pages from failed ones', t => {
 	const report = builder.generateFinalReport();
 
 	t.deepEqual(report.metadata.analyzedPages, ['https://example.com/complete']);
+	t.deepEqual(report.metadata.partialPages, ['https://example.com/partial']);
 	t.deepEqual(report.metadata.failedPages, ['https://example.com/failed']);
-	t.is(report.metadata.totalFindings, 1);
-	t.is(report.pages.length, 2, 'every page appears in the report body');
+
+	// A partial analysis is cut short, not wrong: the findings it did produce
+	// are real observations and must survive into the report.
+	t.is(report.metadata.totalFindings, 2);
+	t.is(report.prioritizedFindings.length, 2);
+	t.is(report.pages.length, 3, 'every page appears in the report body');
 	t.is(report.metadata.persona, 'Test persona');
 
 	sandbox.restore();

--- a/tests/services/report-builder.spec.ts
+++ b/tests/services/report-builder.spec.ts
@@ -45,25 +45,6 @@ const completeOnePage = (builder: ReportBuilder, pageUrl: string) => {
 	builder.completePageAnalysis();
 };
 
-test('discardCurrentPage drops only the in-flight page', t => {
-	const {builder, sandbox} = createBuilder();
-
-	builder.setPersona('Test persona');
-	completeOnePage(builder, 'https://example.com/one');
-
-	builder.initializePageAnalysis('https://example.com/two', 'features');
-	builder.addFinding(buildFinding('https://example.com/two'));
-	builder.discardCurrentPage();
-
-	const state = builder.getCurrentState();
-	t.is(state.currentPageAnalysis, undefined);
-	t.is(state.completedAnalyses.length, 1);
-	t.is(state.completedAnalyses[0]?.pageUrl, 'https://example.com/one');
-	t.is(state.persona, 'Test persona', 'persona must survive a page discard');
-
-	sandbox.restore();
-});
-
 test('failCurrentPage records the failure without destroying earlier pages', t => {
 	const {builder, sandbox} = createBuilder();
 
@@ -108,6 +89,29 @@ test('failCurrentPage synthesises a record when the page never initialised', t =
 	t.is(failed.status, 'failed');
 	t.is(failed.error, 'MCP client unavailable');
 	t.is(builder.getCurrentState().completedAnalyses.length, 1);
+
+	sandbox.restore();
+});
+
+test('failCurrentPage does not re-record a page that already finished', t => {
+	const {builder, sandbox} = createBuilder();
+
+	// The model completes the page, then something after that throws inside the
+	// same try block. Without a guard the page lands in analyzedPages *and*
+	// failedPages, and a finished page gets reported as failed.
+	completeOnePage(builder, 'https://example.com/one');
+
+	const result = builder.failCurrentPage('progress subscriber blew up', {
+		url: 'https://example.com/one',
+		features: 'features',
+	});
+
+	t.is(result.status, 'complete', 'the settled record wins');
+
+	const report = builder.generateFinalReport();
+	t.deepEqual(report.metadata.analyzedPages, ['https://example.com/one']);
+	t.deepEqual(report.metadata.failedPages, []);
+	t.is(report.pages.length, 1, 'the page must appear exactly once');
 
 	sandbox.restore();
 });


### PR DESCRIPTION
## Summary

Five data-integrity bugs in the report pipeline, all sitting in the same code path between `AIService.analyzePage()` and `ReportBuilder`. Together they meant the generated report could not be trusted to describe what actually happened during a run.

These block the next two planned pieces of work: a CI gate cannot fail a truncated run it has no way to recognise, and "the report is equivalent before and after" is not a checkable criterion while the report randomly loses pages.

| # | Bug | Effect |
|---|-----|--------|
| B1 | `analyzePage()`'s catch called `reportBuilder.reset()`, which empties `allAnalyses` | One failing page erased **every page already analysed**. A 5-page run that stumbled on page 3 shipped an empty report. |
| B2 | The failed `PageAnalysis` was hand-built and returned to a caller that discarded it; nothing pushed it into the collection | `metadata.failedPages` was **structurally always empty** — a failed run and a clean run produced identical reports. |
| B3 | The iteration-exhausted fallback called `completePageAnalysis()`, which hardcoded `status: 'complete'` | A sweep cut off after 20 iterations was **indistinguishable from a finished one**. |
| B4 | `close()` shut the MCP client down but left the instance in the `getAIService` cache | A second run in the same process reused it and failed on a **dead transport**. |
| B5 | `setPersona()` had exactly one caller: the **catch block** | A run where every page succeeded shipped a report with a blank Target Persona. The persona only appeared if a page had failed. |

B5 was not in the original list — it surfaced while reading the code for the others.

## Changes

**`ReportBuilder`** — the run-level `reset()` was doing two different jobs. `failCurrentPage(error, page)` now records a page as failed and moves it into the collection; `reset()` keeps its old meaning and is only used at run boundaries. `completePageAnalysis(status = 'complete')` accepts `'partial'`.

**`AnalysisStatus`** gains `'partial'`; **`ReportMetadata`** gains `partialPages: string[]`.

Partial findings **still count** toward totals and prioritised findings. The page stopped early, but what it did observe is as real as anything from a finished page — dropping those findings would make the new status worse than having no status at all.

**Report output** flags partial pages in the header and in their section heading, and the Failed Pages section now prints the recorded reason instead of a bare URL.

**`ci-runner`** logs each page's terminal status and the analysed/partial/failed counts. Exit codes are deliberately untouched — see Out of scope.

## Review round

A `/code-review high` pass over the first four commits found two problems **in the fixes themselves**, both now addressed in `9da10de`:

- **The B4 cache eviction did not work.** `getMCPClient()` memoises the transport at module scope and nothing cleared it, so the next `getAIService()` built a fresh service around the same closed client. Worse, that instance was not itself closed, so the friendly guard added for this exact case never fired. `close()` now clears both caches.
- **`failCurrentPage` could double-record a page.** "No in-flight page" means either "never initialised" or "already finished". A throw after the model completed a page appended a second record, putting one URL in both `analyzedPages` and `failedPages`. It now returns the settled record.

Also from that pass: the closed-service guard no longer writes through the shared `ReportBuilder` singleton (it would have planted a phantom failed page in the *next* run's report); the summary sentence no longer credits partial findings to the successful page count; and `discardCurrentPage()` was removed as it had no production caller.

## Tests

`ReportBuilder` and the report generator both had **no tests at all** despite being pure functions/classes that Constitution II puts under unit tests. That gap is why B1–B3 survived: they all live in the boundary between "this page ended" and "the run ended", and nothing exercised it.

- New `tests/services/report-builder.spec.ts` — termination paths, aggregation split, the double-record guard
- New `tests/infrastructure/reports/report-generator.spec.ts` — partial flagging, failure reason rendering
- `tests/services/ai-service.spec.ts` — mid-run failure across multiple pages, failed-page recording, iteration exhaustion, post-close behaviour

The existing AIService tests called `setPersona()` themselves before generating a report, standing in for a production call that was never there. That crutch is removed, so those assertions now cover the real path.

**294 tests pass.** Gates run in constitution order: `compile` → `format` → `lint`.

## Notes for the reviewer

- **`ReportMetadata.partialPages` is required, not optional.** Two test fixtures in this repo needed updating. Making it optional would let a report silently omit partial pages, which reintroduces exactly the ambiguity being fixed. This package ships as a CLI, so the type is not a load-bearing public API.
- **`failCurrentPage` scans backwards with an index loop** rather than `findLast`. `tsconfig.json` sets `lib: ES2022` and `findLast` is ES2023. Node 22 supports it, so the lib setting is arguably stale — but correcting it belongs in its own change, not bundled into a bug fix.
- Not verified end-to-end against a live LLM and browser; the failure paths are covered by `MockLanguageModelV4` regressions instead.

## Out of scope

- **CI exit codes / thresholds.** The runner still exits 0 when pages fail. That is the `ci-gate` feature; this PR only makes the data that gate will read trustworthy.
- **The process-global `reportBuilder` / MCP client singletons.** They are the root cause behind B1 and B4 and go away when the agent loop moves to the SDK and state moves into `toolsContext`. The fixes here are narrow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Reports now distinguish complete, partial, and failed page analyses.
  - Partial pages include warning messages and their available findings.
  - Failed pages display recorded error details.
  - Completion summaries include analyzed, partial, and failed page counts.

- **Bug Fixes**
  - Earlier findings are preserved when a later page fails.
  - Analysis services now reject work after being closed.
  - Reports prevent duplicate completion or failure records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->